### PR TITLE
Refactor Profilers & Add Commandline Runner.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+results.json

--- a/index.html
+++ b/index.html
@@ -13,6 +13,10 @@
 <script src="js/libs/ember-1.0.0.prod.js"></script>
 <script src="js/app.js"></script>
 <script src="js/models.js"></script>
+<script src="js/profilers/object_create.js"></script>
+<script src="js/profilers/render_list.js"></script>
+<script src="js/profilers/template_binding.js"></script>
+<script src="js/profilers/html_binding.js"></script>
 <script src="js/helpers.js"></script>
 
 <script type="text/x-handlebars" data-template-name="listItems">

--- a/js/app.js
+++ b/js/app.js
@@ -1,121 +1,27 @@
 Perf = Ember.Application.create();
 
-var renderToScratch = function(template, args) {
-  var viewArgs = {templateName: template}
-  var view = Ember.View.create(jQuery.extend(viewArgs, args || {}));
-  view.appendTo('#scratch');
-  return view;
-}
-
 Perf.ApplicationRoute = Em.Route.extend({
 
   model: function() {
-    return Perf.Profiler.instance();
+    return Perf.ProfilerDisplay.instance();
   },
 
   events: {
 
-    /**
-      Profiles the creation of Ember.Objects.
-    **/
     profObjectCreate: function() {
-      Perf.Profiler.profile("Object.create()", 50, function() {
-        for (var i=0; i<10000; i++) {
-          var instance = Ember.Object.create({});
-        }
-      });
+      Perf.ObjectCreateProfiler.create().profile();
     },
 
-    /**
-      Profiles the rendering of a list of many bound items.
-    **/
     profRenderList: function () {
-      var listItems = [];
-      for (var i=0; i<5000; i++) {
-        listItems.push("Item " + (i + 1));
-      }
-
-      Perf.Profiler.profile("Render List", 20, function(result) {
-        var promise = Ember.Deferred.create();
-
-        var listItemsView = renderToScratch('listItems', {listItems: listItems});
-        Em.run.next(function() {
-          // stop timing before we clean up
-          result.stop();
-
-          // clean up stuff
-          listItemsView.destroy();
-          promise.resolve();
-        });
-
-        return promise;
-      });
+      Perf.RenderListProfiler.create().profile();
     },
 
-    /**
-      Renders a list of items, then changes them all.
-    **/
     profTemplateBindings: function() {
-      var people = [],
-          lastAge = 1;
-
-      var nextAge = function() {
-        lastAge++;
-        if (lastAge > 99) { lastAge = 1; }
-        return lastAge;
-      }
-
-      for (var i=0; i<500; i++) {
-        people.push(Em.Object.create({name: "Person " + i, age: nextAge()}));
-      }
-
-      var templateBindingsView = renderToScratch('templateBindings', {people: people});
-      Perf.Profiler.profile("Template Bindings", 40, function(result) {
-        var promise = Ember.Deferred.create();
-        for (var i=0; i<people.length; i++) {
-          people[i].set('age', nextAge());
-        }
-
-        Em.run.next(function() {
-          result.stop();
-
-          // clean up stuff
-          promise.resolve();
-        });
-
-        return promise;
-
-      }).then(function () {
-        templateBindingsView.destroy();
-      });
+      Perf.TemplateBindingProfiler.create().profile();
     },
 
-    /**
-      Renders a view with a binding that contains a lot of HTML. The idea
-      here is to check how the W3C Range API performs on large chunks of HTML
-      nodes.
-    **/
     profHtmlBindings: function() {
-      var largeHtmlChunk = "<ul>";
-      for (var i=0; i<5000; i++) {
-        largeHtmlChunk += "<li>Evil Trout</li>";
-      }
-      largeHtmlChunk += "</ul>";
-
-      var htmlBindingsView = renderToScratch('htmlBindings');
-      Perf.Profiler.profile("HTML Bindings", 40, function(result) {
-        var promise = Ember.Deferred.create();
-
-        htmlBindingsView.set('html', largeHtmlChunk)
-        Em.run.next(function() {
-          result.stop();
-
-          // clean up stuff
-          htmlBindingsView.set('html', '');
-          promise.resolve();
-        });
-        return promise;
-      });
+      Perf.HtmlBindingProfiler.create().profile();
     }
 
   }

--- a/js/profilers/html_binding.js
+++ b/js/profilers/html_binding.js
@@ -1,0 +1,42 @@
+/**
+  Renders a view with a binding that contains a lot of HTML. The idea
+  here is to check how the W3C Range API performs on large chunks of HTML
+  nodes.
+**/
+Perf.HtmlBindingProfiler = Perf.Profiler.extend({
+  testCount: 40,
+  name: 'HTML Bindings',
+
+  setup: function(){
+    var largeHtmlChunk = "<ul>";
+    for (var i=0; i<5000; i++) {
+      largeHtmlChunk += "<li>Evil Trout</li>";
+    }
+    largeHtmlChunk += "</ul>";
+
+    this.setProperties({
+      'htmlBindingsView': this.renderToScratch('htmlBindings'),
+      'largeHtmlChunk': largeHtmlChunk
+    });
+  },
+
+  test: function(){
+    var promise          = Ember.Deferred.create(),
+        htmlBindingsView = this.get('htmlBindingsView'),
+        result           = this.get('result');
+
+    htmlBindingsView.set('html', this.get('largeHtmlChunk'))
+    Em.run.next(function() {
+      result.stop();
+
+      // clean up stuff
+      htmlBindingsView.set('html', '');
+      promise.resolve();
+    });
+    return promise;
+  },
+
+  teardown: function(){
+    this.get('htmlBindingsView').destroy();
+  }
+});

--- a/js/profilers/object_create.js
+++ b/js/profilers/object_create.js
@@ -1,0 +1,13 @@
+/**
+  Profiles the creation of Ember.Objects.
+**/
+Perf.ObjectCreateProfiler = Perf.Profiler.extend({
+  testCount: 50,
+  name: 'Object.create()',
+
+  test: function() {
+    for (var i=0; i<10000; i++) {
+      var instance = Ember.Object.create();
+    }
+  }
+});

--- a/js/profilers/render_list.js
+++ b/js/profilers/render_list.js
@@ -1,0 +1,33 @@
+/**
+  Profiles the rendering of a list of many bound items.
+**/
+Perf.RenderListProfiler = Perf.Profiler.extend({
+  testCount: 20,
+  name: 'Render List',
+
+  setup: function(){
+    var listItems = [];
+    for (var i=0; i<5000; i++) {
+      listItems.push("Item " + (i + 1));
+    }
+
+    this.set('listItems', listItems);
+  },
+
+  test: function() {
+    var promise = Ember.Deferred.create(),
+        result  = this.get('result');
+
+    var listItemsView = this.renderToScratch('listItems', {listItems: this.get('listItems')});
+    Em.run.next(function() {
+      // stop timing before we clean up
+      result.stop();
+
+      // clean up stuff
+      listItemsView.destroy();
+      promise.resolve();
+    });
+
+    return promise;
+  }
+});

--- a/js/profilers/template_binding.js
+++ b/js/profilers/template_binding.js
@@ -1,0 +1,54 @@
+/**
+  Renders a list of items, then changes them all.
+**/
+Perf.TemplateBindingProfiler = Perf.Profiler.extend({
+  testCount: 40,
+  name: 'Template Bindings',
+  lastAge: 1,
+
+  setup: function(){
+    var people = [];
+
+    for (var i=0; i<500; i++) {
+      people.push(Em.Object.create({name: "Person " + i, age: this.nextAge()}));
+    }
+
+    var templateBindingsView = this.renderToScratch('templateBindings', {people: people});
+
+    this.set('people', people);
+    this.set('templateBindingsView', templateBindingsView);
+  },
+
+  test: function() {
+    var promise              = Ember.Deferred.create(),
+        people               = this.get('people'),
+        result               = this.get('result'),
+        templateBindingsView = this.get('templateBindingsView');
+
+    for (var i=0; i<people.length; i++) {
+      people[i].set('age', this.nextAge());
+    }
+
+    Em.run.next(function() {
+      result.stop();
+
+      // clean up stuff
+      promise.resolve();
+    });
+
+    return promise;
+  },
+
+  teardown: function(){
+    this.get('templateBindingsView').destroy();
+  },
+
+  
+  nextAge: function() {
+    this.incrementProperty('lastAge');
+    if (this.get('lastAge') > 99) { this.set('lastAge', 1)}
+
+    return this.get('lastAge');
+  }
+
+});

--- a/runner.js
+++ b/runner.js
@@ -1,0 +1,54 @@
+var args = phantom.args;
+if (args.length < 1 || args.length > 2) {
+    console.log("Usage: " + phantom.scriptName + " <URL> <timeout>");
+      phantom.exit(1);
+}
+
+var fs   = require('fs'),
+    page = require('webpage').create();
+
+page.open(args[0], function(status) {
+  if (status !== 'success') {
+    console.error("Unable to access page.");
+    phantom.exit(1);
+  } 
+});
+
+page.onLoadFinished = function() {
+  var promise = page.evaluate(runPerformanceTests),
+      timeout = parseInt(args[1] || 60000, 10),
+      start   = Date.now();
+
+  var interval = setInterval(function() {
+    if (Date.now() > start + timeout) {
+      console.error("Timed out");
+      phantom.exit(124);
+    } else {
+      var results = page.evaluate(function(){
+        return window.performanceResults;
+      });
+
+      if (results) {
+        clearInterval(interval);
+        fs.write('results.json', JSON.stringify(results));
+        phantom.exit();
+      }
+    }
+  }, 500);
+}
+
+function runPerformanceTests(){
+  var promise = Ember.RSVP.resolve(true);
+
+  return promise
+    .then(function(){ return Perf.ObjectCreateProfiler.create().profile(); })
+    .then(function(){ return Perf.TemplateBindingProfiler.create().profile(); })
+    .then(function(){ return Perf.HtmlBindingProfiler.create().profile(); })
+
+    .then(function(){
+      var display = Perf.ProfilerDisplay.instance();
+      window.performanceResults = display.get('results').mapBy('dump');
+
+      return true;
+    });
+};


### PR DESCRIPTION
The major parts of this are:
- Perf.Profile is no longer a singleton.
- Perf.Profile is extended to make individual objects for each profile task.
- Each `Profiler` should implement the following:
  - name - The name of the test.
  - runCount - The count of runs for this particular profile.
  - setup (**optional**) - This is run once before the actual method profile is started the first time.
  - test - This is the actual method being run.
  - teardown (**optional**) - Do any cleanup after the suite has finished.
- `Perf.ProfilerDisplay` was added as the main `ApplicationRoute` model.
- A console runner has been added.

**NOTE**: The original UI is still intact and fully functional.
#### Console Runner

Run with the following:

```
phantomjs runner.js index.html
```

The runner will create a results.json file in the project directory.  I plan to change this in the future to report the test results to an external API server.

File format:

``` javascript
[{"geometricMean":31.563778382196222,"mean":31.68,"name":"Object.create()","runCount":50,"standardDeviation":2.7308606701917246,"times":[29,33,34,37,33,28,28,30,27,30,30,28,35,39,34,29,35,29,30,30,33,34,32,34,33,31,33,30,30,34,33,31,30,33,37,30,33,33,30,33,33,36,27,28,29,28,30,32,33,33]},
 {"geometricMean":28.013807173417142,"mean":28.125,"name":"Template Bindings","runCount":40,"standardDeviation":2.5902461273014192,"times":[27,29,28,26,27,35,31,27,27,28,27,34,28,28,27,27,35,28,28,27,29,28,33,25,26,25,25,33,28,28,25,25,26,29,27,28,27,27,30,27]},
 {"geometricMean":19.179961026735317,"mean":19.225,"name":"HTML Bindings","runCount":40,"standardDeviation":1.31315459866689,"times":[19,18,17,20,19,20,20,20,20,20,20,20,20,21,20,23,18,17,17,17,17,17,20,21,19,20,20,19,20,19,19,20,19,18,19,19,19,21,18,19]}]
```
