### PR TITLE
Allow easier local dev with canary versions.

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,11 +11,23 @@
 <script src="js/libs/ascii-table.min.js"></script>
 <script src="js/libs/jquery-1.9.1.js"></script>
 <script>
+  var handlebarsLib = "js/libs/handlebars-v1.3.0.js";
+
   if(window.location.search){
-    window.testVersion = window.location.search.split("=")[1];
+    (function() {
+      var params = window.location.search.slice(1).split('&');
+      for (var i = 0, l = params.length; i < l; i++) {
+        var parts = params[i].split('=');
+
+        if (parts[0] === 'ember') {
+          window.testVersion = parts[1];
+        } else if (parts[0] === 'handlebars') {
+          handlebarsLib = parts[1];
+        }
+      }
+    })()
   }
 
-  var handlebarsLib = "js/libs/handlebars-v1.3.0.js";
   window.testVersion = window.testVersion || "http://builds.emberjs.com/canary/ember.prod.js";
 
   // Canary requires handlebars 2.0

--- a/js/models.js
+++ b/js/models.js
@@ -19,7 +19,7 @@ Perf.ProfilerDisplay = Ember.Object.extend({
   },
 
   selectedVersionChanged: function(){
-    window.location.href = window.location.pathname + "?v=" + this.get('selectedVersion');
+    window.location.href = window.location.pathname + "?ember=" + this.get('selectedVersion');
   }.observes('selectedVersion'),
 
   clearResults: function() {


### PR DESCRIPTION
This allows specifying the Ember and Handlebars versions in the query string. Added to enable easier local testing against canary versions of Ember (just run `ember serve --environment=production` in Ember repo) via:

/ember-performance/index.html?ember=http://localhost:4200/ember.prod.js&handlebars=http://localhost:4200/handlebars/handlebars.js
