### PR TITLE
Upgrade to bootstrap-sass

### DIFF
--- a/Brocfile.js
+++ b/Brocfile.js
@@ -61,11 +61,7 @@ var appJs = concat(mergeTrees([
 });
 
 var appCss = compileSass(['app/styles'], 'app.scss', 'assets/app.css');
-
-var vendorCss = concat(mergeTrees(findBowerTrees()), {
-  inputFiles: ['bootstrap.css'],
-  outputFile: '/assets/vendor.css'
-});
+var vendorCss = compileSass(['app/styles'], 'vendor.scss', 'assets/vendor.css');
 
 env('production', function() {
   vendorJs = uglifyJavaScript(vendorJs);

--- a/app/styles/vendor.scss
+++ b/app/styles/vendor.scss
@@ -1,0 +1,1 @@
+@import "bower_components/bootstrap-sass/assets/stylesheets/bootstrap";

--- a/bower.json
+++ b/bower.json
@@ -13,7 +13,7 @@
     "tests"
   ],
   "dependencies": {
-    "bootstrap": "~3.3.1",
+    "bootstrap-sass": "~3.3.5",
     "jquery": "~2.1.1",
     "benchmark": "git@github.com:bestiejs/benchmark.js.git",
     "headjs": "~1.0.3",


### PR DESCRIPTION
Fixes #41 

The current app ships with a dependency on `bootstrap` which only ships with a `.less` file. Moving to the official `bootstrap-sass` library means we can take advantage of the existing `broccoli-sass` plugin