### PR TITLE
Lock to RSVP 3.0.13.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,7 @@
     "jquery": "~2.1.1",
     "benchmark": "git@github.com:bestiejs/benchmark.js.git",
     "headjs": "~1.0.3",
-    "rsvp": "~3.0.13",
+    "rsvp": "3.0.13",
     "ascii-table": "~0.0.4",
     "numeraljs": "~1.5.3"
   }


### PR DESCRIPTION
Using `broccoli-bower` with the latest RSVP causes an error (because `RSVP`'s `bower.json` has an invalid `main` entry point).

This locks it down to a working version, but longer term we should refactor the `Brocfile.js` to avoid `broccoli-bower`.