### PR TITLE
include assets/test.css in output

### DIFF
--- a/Brocfile.js
+++ b/Brocfile.js
@@ -61,12 +61,14 @@ var appJs = concat(mergeTrees([
 });
 
 var appCss = compileSass(['app/styles'], 'app.scss', 'assets/app.css');
+var testCss = compileSass(['app/styles'], 'test.scss', 'assets/test.css');
 var vendorCss = compileSass(['app/styles'], 'vendor.scss', 'assets/vendor.css');
 
 env('production', function() {
   vendorJs = uglifyJavaScript(vendorJs);
   testClient = uglifyJavaScript(testClient);
   vendorCss = cleanCSS(vendorCss);
+  testCss = cleanCSS(testCss);
   appCss = cleanCSS(appCss);
 });
 
@@ -76,6 +78,7 @@ module.exports = mergeTrees([
   appCss,
   vendorJs,
   vendorCss,
+  testCss,
   testClient,
   testTree,
   emberTree


### PR DESCRIPTION
This fixes the 404 when running tests:

![image](https://cloud.githubusercontent.com/assets/2526/9928859/de98b726-5d20-11e5-83aa-d9602e572c65.png)
