### PR TITLE
add more common variations of `Ember.Object.create`

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -25,6 +25,13 @@
     { name: 'object-create/baseline',    path: '/object-create/baseline'   },
     { name: 'object-create/index',       path: '/object-create' },
 
+    // Basically, browisers (v8 included have mega slow defineProp ...)
+    // - https://code.google.com/p/v8/issues/detail?id=3649
+    // - there is a FF ticket I opened, but couldn't find it quickly :P
+    // - Jakob is working on it from the v8 side.
+    { name: 'object-create/without-non-enumerable-safety', path: '/object-create/without-non-enumerable-safety' },
+    { name: 'object-create/without-non-enumerable-safety-same-class', path: '/object-create/without-non-enumerable-safety-same-class' },
+
     { name: 'Render List',               path: '/render-list'   },
     { name: 'Render List (Unbound)',     path: '/render-list-unbound' },
     { name: 'Render Complex List',       path: '/render-complex-list' },

--- a/tests/object-create/without-non-enumerable-safety-same-class/index.js
+++ b/tests/object-create/without-non-enumerable-safety-same-class/index.js
@@ -1,0 +1,25 @@
+/* global TestClient */
+var S;
+function makeS() {
+  if (S) { return S;}
+  S = Ember.Object.extend({
+    __defineNonEnumerable: function(property) {
+      this[property.name] = property.descriptor.value;
+    }
+  });
+
+  S.create();
+  return S;
+}
+
+MicroTestClient.run({
+  name: 'Ember.Object.create (without non-enumerable safety but same class)[Common Case]',
+
+  setup: function() {
+    var Subclass = makeS();
+  },
+
+  test: function() {
+    Subclass.create();
+  }
+});

--- a/tests/object-create/without-non-enumerable-safety/index.js
+++ b/tests/object-create/without-non-enumerable-safety/index.js
@@ -1,0 +1,16 @@
+/* global TestClient */
+MicroTestClient.run({
+  name: 'Ember.Object.create (without non-enumerable safety)',
+
+  setup: function() {
+    var Subclass = Ember.Object.extend({
+      __defineNonEnumerable: function(property) {
+        this[property.name] = property.descriptor.value;
+      }
+    });
+  },
+
+  test: function() {
+    Subclass.create();
+  }
+});


### PR DESCRIPTION
* internal objects (views/ember-data models) go down a non-default fast-path to above the overhead of Object.defineProperty
* there is also a perf difference between the first instance for a given class, and the nth. (benchmark hits both)