### PR TITLE
extract benchmark-report component

### DIFF
--- a/app/components/benchmark-report.js
+++ b/app/components/benchmark-report.js
@@ -1,0 +1,73 @@
+import Ember from 'ember';
+import numeral from 'numeral';
+
+var EMBER_PERF_VERSION = "0.9.2"; // TODO: get from package.json
+
+export default Ember.Component.extend({
+  mode: 'html',
+  isHtmlMode: Ember.computed.equal('mode', 'html'),
+  isTextMode: Ember.computed.equal('mode', 'text'),
+  canSubmitStats: Ember.computed.equal('report.testGroupReports.length', 1),
+
+  asciiTable: function() {
+    var result = 'User Agent: ' + navigator.userAgent + "\n";
+
+    var featureFlags = this.get('report.featureFlags');
+    if (featureFlags && featureFlags.length) {
+      result += 'Feature Flags: ' + featureFlags.join(', ') + "\n";
+    }
+    result += '\n';
+
+    var table = new window.AsciiTable('Ember Performance Suite - Results');
+    table.setHeading('Name', 'Speed', 'Error', 'Samples', 'Mean');
+
+    this.get('report.testGroupReports').forEach(function(testGroupReport) {
+      table.addRow(" -- Ember " + testGroupReport.emberVersion.name + " -- ");
+
+      testGroupReport.results.forEach(function(result) {
+        table.addRow(result.name,
+                     numeral(result.hz).format("0.00") + " / sec",
+                     "∓" + numeral(result.rme).format("0.00") + "%",
+                     numeral(result.samples).format(),
+                     numeral(result.mean).format("0.00") + " ms");
+      });
+    });
+
+    return result + table.toString();
+  }.property('report.testGroupReports.[]'),
+
+  actions: {
+    switchMode: function(mode) {
+      this.set('mode', mode);
+    },
+    submitResults: function() {
+      var controller = this;
+
+      this.set('sending', true);
+      this.set('error', false);
+
+      var reportJson = this.get('report'); //TODO: GJ: fix this https://github.com/eviltrout/ember-performance/issues/69
+      reportJson.emberPerfVersion = EMBER_PERF_VERSION;
+
+      new Ember.RSVP.Promise(function (resolve, reject) {
+        Ember.$.ajax({
+          url: 'http://perflogger.eviltrout.com/api/results',
+          type: 'POST',
+          data: { results: JSON.stringify(reportJson) },
+          success: function(result) {
+            Ember.run(null, resolve, result);
+          },
+          error: function(result) {
+            Ember.run(null, reject, result);
+          }
+        });
+      }).then(function() {
+        controller.set('sent', true);
+      }).catch(function() {
+        controller.set('error', true);
+      }).finally(function() {
+        controller.set('sending', false);
+      });
+    },
+  }
+});

--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -1,14 +1,5 @@
 import Ember from 'ember';
 
-function roundedNumber(num) {
-  if (num) {
-    return Math.round(num * 100, 10) / 100.0;
-  }
-  return num;
-}
-
-var EMBER_PERF_VERSION = "0.9.2"; // TODO: get from package.json
-
 export default Ember.Controller.extend({
   init: function() {
     this._super.apply(this, arguments);
@@ -25,35 +16,9 @@ export default Ember.Controller.extend({
   enabledEmberVersions: Ember.computed.filterBy('emberVersions', 'isEnabled', true),
   addFeatureDisabled: Ember.computed.empty('newFlagName'),
   customEmberVersion: Ember.computed.reads('emberVersions.lastObject'),
-  canSubmitStats: Ember.computed.equal('report.testGroupReports.length', 1),
   hasNoEnabledTests: Ember.computed.empty('enabledTests'),
   hasNoEnabledEmberVersions: Ember.computed.empty('enabledEmberVersions'),
   cantStart: Ember.computed.or('hasNoEnabledTests', 'hasNoEnabledEmberVersions'),
-
-  asciiTable: function() {
-    var result = 'User Agent: ' + navigator.userAgent + "\n";
-
-    var featureFlags = this.get('report.featureFlags');
-    if (featureFlags && featureFlags.length) {
-      result += 'Feature Flags: ' + featureFlags.join(', ') + "\n";
-    }
-    result += '\n';
-
-    var table = new window.AsciiTable('Ember Performance Suite - Results');
-    table.setHeading('Name', 'Speed', 'Error', 'Samples', 'Mean');
-
-    this.get('report.testGroupReports').forEach(function(testGroupReport) {
-      testGroupReport.results.forEach(function(result) {
-        table.addRow(result.name + " (" + testGroupReport.emberVersion.name + ")",
-                     roundedNumber(result.hz),
-                     "∓" + roundedNumber(result.rme) + "%",
-                     roundedNumber(result.samples),
-                     roundedNumber(result.mean));
-      });
-    });
-
-    return result + table.toString();
-  }.property('report.testGroupReports.[]'),
 
   run: function(options) {
     options = options || {};
@@ -82,36 +47,6 @@ export default Ember.Controller.extend({
   },
 
   actions: {
-    submitResults: function() {
-      var controller = this;
-
-      this.set('sending', true);
-      this.set('error', false);
-
-      var reportJson = this.get('report');
-      reportJson.emberPerfVersion = EMBER_PERF_VERSION;
-
-      new Ember.RSVP.Promise(function (resolve, reject) {
-        Ember.$.ajax({
-          url: 'http://perflogger.eviltrout.com/api/results',
-          type: 'POST',
-          data: { results: JSON.stringify(reportJson) },
-          success: function(result) {
-            Ember.run(null, resolve, result);
-          },
-          error: function(result) {
-            Ember.run(null, reject, result);
-          }
-        });
-      }).then(function() {
-        controller.set('sent', true);
-      }).catch(function() {
-        controller.set('error', true);
-      }).finally(function() {
-        controller.set('sending', false);
-      });
-    },
-
     profile: function() {
       this.run({ enableProfile: true });
     },

--- a/app/templates/components/benchmark-report.hbs
+++ b/app/templates/components/benchmark-report.hbs
@@ -1,0 +1,61 @@
+<h4>Results:</h4>
+
+<ul class="nav nav-tabs">
+  <li role="presentation" class="{{if isHtmlMode 'active'}}">
+    <a href {{action "switchMode" "html"}}>HTML</a>
+  </li>
+  <li role="presentation" class="{{if isTextMode 'active'}}">
+    <a href {{action "switchMode" "text"}}>Text</a>
+  </li>
+</ul>
+
+{{#if isHtmlMode}}
+  {{#each report.testGroupReports as |testGroupReport|}}
+    <table class='table'>
+      <thead>
+        <tr>
+          <th>Ember {{testGroupReport.emberVersion.name}}</th>
+          <th class="numeric">Speed</th>
+          <th class="numeric">Error</th>
+          <th class="numeric">Samples</th>
+          <th class="numeric">Mean</th>
+        </tr>
+      </thead>
+      <tbody>
+        {{#each testGroupReport.results as |result|}}
+          <tr>
+            <td>{{result.name}}</td>
+            <td class="numeric">{{format-number result.hz format="0.00"}} / sec</td>
+            <td class="numeric">&#x2213; {{format-number result.rme format="0.00"}}%</td>
+            <td class="numeric">{{result.samples}}</td>
+            <td class="numeric">{{format-number result.mean format="0.00"}} ms</td>
+          </tr>
+        {{/each}}
+      </tbody>
+    </table>
+  {{/each}}
+{{else}}
+  <pre class='text-results'>{{{asciiTable}}}</pre>
+{{/if}}
+
+{{#if canSubmitStats}}
+  <div class='well'>
+    {{#unless sent}}
+      <p>Would you like to submit your results to help the Ember tuning effort? The server is maintained by
+         by <a href='http://eviltrout.com'>eviltrout</a> and the only identifying information stored is your
+         browser's user agent.</p>
+
+      <button class='btn btn-primary' {{action "submitResults"}}>Submit my Results</button>
+      {{#if sending}}
+        Sending...
+      {{/if}}
+
+      {{#if error}}
+        <div class='alert alert-danger'><strong>Error Sending Results</strong> perhaps there is a problem with the remote server?</div>
+      {{/if}}
+    {{else}}
+      Thanks for sending your results.
+    {{/unless}}
+  </div>
+{{/if}}
+<hr>

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -1,28 +1,5 @@
 {{#if report}}
-  <h4>Results:</h4>
-  <pre class='text-results'>{{{asciiTable}}}</pre>
-
-  {{#if canSubmitStats}}
-    <div class='well'>
-      {{#unless sent}}
-        <p>Would you like to submit your results to help the Ember tuning effort? The server is maintained by
-           by <a href='http://eviltrout.com'>eviltrout</a> and the only identifying information stored is your
-           browser's user agent.</p>
-
-        <button class='btn btn-primary' {{action "submitResults"}}>Submit my Results</button>
-        {{#if sending}}
-          Sending...
-        {{/if}}
-
-        {{#if error}}
-          <div class='alert alert-danger'><strong>Error Sending Results</strong> perhaps there is a problem with the remote server?</div>
-        {{/if}}
-      {{else}}
-        Thanks for sending your results.
-      {{/unless}}
-    </div>
-  {{/if}}
-  <hr>
+  {{benchmark-report report=report}}
 {{/if}}
 
 <h4>

--- a/bower.json
+++ b/bower.json
@@ -22,6 +22,7 @@
     "loader.js": "ember-cli/loader.js#3.2.1",
     "numeraljs": "~1.5.3",
     "qunit": "~1.18.0",
-    "bootstrap": "~3.3.2"
+    "bootstrap": "~3.3.2",
+    "numeral": "~1.5.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "node": ">= 0.10.0"
   },
   "author": "Robin Ward",
-  "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.1.2",
     "broccoli-bower": "^0.2.1",
@@ -32,6 +31,7 @@
     "ember-cli-app-version": "0.5.0",
     "ember-cli-babel": "^5.1.3",
     "ember-cli-dependency-checker": "^1.0.1",
+    "ember-cli-format-number": "1.0.2",
     "ember-cli-htmlbars": "0.7.9",
     "ember-cli-htmlbars-inline-precompile": "^0.2.0",
     "ember-cli-ic-ajax": "0.2.1",


### PR DESCRIPTION
This adds back the HTML report and simplifies the index controller by extracting the report behavior to a component. 

The 'Submit my Results' function is broken on master, I'll fix this weekend (https://github.com/eviltrout/ember-performance/issues/69)