### PR TITLE
Add ability to test minified Ember versions.

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -7,9 +7,14 @@ var concat = require('broccoli-concat');
 var findBowerTrees = require('broccoli-bower');
 var copyIndex = require('./lib/copy-index');
 var Funnel = require('broccoli-funnel');
+var uglify = require('broccoli-uglify-js');
 
 var compileTemplatesTree = find('compile-templates');
 var emberTree = find('ember/**/*.js');
+
+if (EmberApp.env() === 'production') {
+  emberTree = uglify(emberTree);
+}
 
 var clientTree = mergeTrees([
   'test-client',

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "broccoli-funnel": "^0.2.8",
     "broccoli-merge-trees": "^0.2.3",
     "broccoli-stew": "^0.1.2",
+    "broccoli-uglify-js": "^0.1.3",
     "ember-bootstrap": "0.4.0",
     "ember-cli": "1.13.8",
     "ember-cli-app-version": "0.5.0",


### PR DESCRIPTION
Running `production` environment will now use minified Ember versions.

Usage:

```
ember serve -prod
```

This better simulates normal production usage (since the majority of our deployed code will be using minfication).