### PR TITLE
Use official 2.1.0 builds.

### DIFF
--- a/ember/ember-2.1.0.prod.js
+++ b/ember/ember-2.1.0.prod.js
@@ -5,7 +5,7 @@
  *            Portions Copyright 2008-2011 Apple Inc. All rights reserved.
  * @license   Licensed under MIT license
  *            See https://raw.github.com/emberjs/ember.js/master/LICENSE
- * @version   2.1.0+45f524a3
+ * @version   2.1.0
  */
 
 (function() {
@@ -8441,7 +8441,7 @@ enifed('ember-htmlbars/keywords/outlet', ['exports', 'ember-metal/core', 'ember-
 
   'use strict';
 
-  _emberHtmlbarsTemplatesTopLevelView.default.meta.revision = 'Ember@2.1.0+45f524a3';
+  _emberHtmlbarsTemplatesTopLevelView.default.meta.revision = 'Ember@2.1.0';
 
   /**
     The `{{outlet}}` helper lets you specify where a child routes will render in
@@ -9491,9 +9491,7 @@ enifed('ember-htmlbars/node-managers/component-node-manager', ['exports', 'ember
   function processNamedPositionalParameters(renderNode, positionalParams, params, attrs) {
     var paramsStartIndex = renderNode.state.isComponentHelper ? 1 : 0;
 
-    var limit = Math.min(params.length, positionalParams.length);
-
-    for (var i = 0; i < limit; i++) {
+    for (var i = 0; i < positionalParams.length; i++) {
       var param = params[paramsStartIndex + i];
 
       
@@ -9502,13 +9500,6 @@ enifed('ember-htmlbars/node-managers/component-node-manager', ['exports', 'ember
   }
 
   function processRestPositionalParameters(renderNode, positionalParamsName, params, attrs) {
-    var nameInAttrs = (positionalParamsName in attrs);
-
-    // when no params are used, do not override the specified `attrs.stringParamName` value
-    if (params.length === 0 && nameInAttrs) {
-      return;
-    }
-
     // If there is already an attribute for that variable, do nothing
     
     var paramsStartIndex = renderNode.state.isComponentHelper ? 1 : 0;
@@ -11380,8 +11371,10 @@ enifed('ember-htmlbars/utils/string', ['exports', 'ember-metal/core', 'ember-run
   */
   function htmlSafe(str) {
     if (str === null || str === undefined) {
-      str = '';
-    } else if (typeof str !== 'string') {
+      return '';
+    }
+
+    if (typeof str !== 'string') {
       str = '' + str;
     }
     return new _htmlbarsUtil.SafeString(str);
@@ -14353,7 +14346,7 @@ enifed('ember-metal/core', ['exports', 'ember-metal/assert'], function (exports,
   
     @class Ember
     @static
-    @version 2.1.0+45f524a3
+    @version 2.1.0
     @public
   */
 
@@ -14387,11 +14380,11 @@ enifed('ember-metal/core', ['exports', 'ember-metal/assert'], function (exports,
   
     @property VERSION
     @type String
-    @default '2.1.0+45f524a3'
+    @default '2.1.0'
     @static
     @public
   */
-  Ember.VERSION = '2.1.0+45f524a3';
+  Ember.VERSION = '2.1.0';
 
   /**
     The hash of environment variables used to control various configuration
@@ -14672,7 +14665,6 @@ enifed('ember-metal/environment', ['exports', 'ember-metal/core'], function (exp
       hasDOM: true,
       isChrome: !!window.chrome && !window.opera,
       isFirefox: typeof InstallTrigger !== 'undefined',
-      isPhantom: !!window.callPhantom,
       location: window.location,
       history: window.history,
       userAgent: window.navigator.userAgent,
@@ -14683,7 +14675,6 @@ enifed('ember-metal/environment', ['exports', 'ember-metal/core'], function (exp
       hasDOM: false,
       isChrome: false,
       isFirefox: false,
-      isPhantom: false,
       location: null,
       history: null,
       userAgent: 'Lynx (textmode)',
@@ -20870,7 +20861,7 @@ enifed('ember-metal/utils', ['exports'], function (exports) {
   var checkHasSuper = (function () {
     var sourceAvailable = (function () {
       return this;
-    }).toString().indexOf('return this') > -1;
+    }).toString().indexOf('return this;') > -1;
 
     if (sourceAvailable) {
       return function checkHasSuper(func) {
@@ -20883,7 +20874,6 @@ enifed('ember-metal/utils', ['exports'], function (exports) {
     };
   })();
 
-  exports.checkHasSuper = checkHasSuper;
   function ROOT() {}
   ROOT.__hasSuper = false;
 
@@ -22571,7 +22561,7 @@ enifed('ember-routing-views/components/link-to', ['exports', 'ember-metal/core',
 
   'use strict';
 
-  _emberHtmlbarsTemplatesLinkTo.default.meta.revision = 'Ember@2.1.0+45f524a3';
+  _emberHtmlbarsTemplatesLinkTo.default.meta.revision = 'Ember@2.1.0';
 
   /**
     `Ember.LinkComponent` renders an element whose `click` event triggers a
@@ -22896,7 +22886,7 @@ enifed('ember-routing-views/components/link-to', ['exports', 'ember-metal/core',
     queryParams: null,
 
     qualifiedRouteName: _emberMetalComputed.computed('targetRouteName', '_routing.currentState', function computeLinkToComponentQualifiedRouteName() {
-      var params = _emberMetalProperty_get.get(this, 'params').slice();
+      var params = this.attrs.params.slice();
       var lastParam = params[params.length - 1];
       if (lastParam && lastParam.isQueryParams) {
         params.pop();
@@ -22988,7 +22978,7 @@ enifed('ember-routing-views/components/link-to', ['exports', 'ember-metal/core',
       var attrs = this.attrs;
 
       // Do not mutate params in place
-      var params = _emberMetalProperty_get.get(this, 'params').slice();
+      var params = attrs.params.slice();
 
       
       if (attrs.disabledWhen) {
@@ -23052,7 +23042,7 @@ enifed('ember-routing-views/views/outlet', ['exports', 'ember-views/views/view',
 
   'use strict';
 
-  _emberHtmlbarsTemplatesTopLevelView.default.meta.revision = 'Ember@2.1.0+45f524a3';
+  _emberHtmlbarsTemplatesTopLevelView.default.meta.revision = 'Ember@2.1.0';
 
   var CoreOutletView = _emberViewsViewsView.default.extend({
     defaultTemplate: _emberHtmlbarsTemplatesTopLevelView.default,
@@ -36699,7 +36689,7 @@ enifed('ember-template-compiler/system/compile_options', ['exports', 'ember-meta
     options.buildMeta = function buildMeta(program) {
       return {
         topLevel: detectTopLevel(program),
-        revision: 'Ember@2.1.0+45f524a3',
+        revision: 'Ember@2.1.0',
         loc: program.loc,
         moduleName: options.moduleName
       };
@@ -40152,7 +40142,7 @@ enifed('ember-views/views/component', ['exports', 'ember-metal/core', 'ember-run
 enifed('ember-views/views/container_view', ['exports', 'ember-metal/core', 'ember-runtime/mixins/mutable_array', 'ember-views/views/view', 'ember-metal/property_get', 'ember-metal/property_set', 'ember-metal/mixin', 'ember-metal/events', 'ember-htmlbars/templates/container-view'], function (exports, _emberMetalCore, _emberRuntimeMixinsMutable_array, _emberViewsViewsView, _emberMetalProperty_get, _emberMetalProperty_set, _emberMetalMixin, _emberMetalEvents, _emberHtmlbarsTemplatesContainerView) {
   'use strict';
 
-  _emberHtmlbarsTemplatesContainerView.default.meta.revision = 'Ember@2.1.0+45f524a3';
+  _emberHtmlbarsTemplatesContainerView.default.meta.revision = 'Ember@2.1.0';
 
   /**
   @module ember

--- a/ember/ember-2.1.0.template-compiler.js
+++ b/ember/ember-2.1.0.template-compiler.js
@@ -5,7 +5,7 @@
  *            Portions Copyright 2008-2011 Apple Inc. All rights reserved.
  * @license   Licensed under MIT license
  *            See https://raw.github.com/emberjs/ember.js/master/LICENSE
- * @version   2.1.0+45f524a3
+ * @version   2.1.0
  */
 
 (function() {
@@ -1572,11 +1572,6 @@ enifed('ember-debug/deprecate', ['exports', 'ember-metal/core', 'ember-metal/err
 
   exports.missingOptionsUntilDeprecation = missingOptionsUntilDeprecation;
   /**
-  @module ember
-  @submodule ember-debug
-  */
-
-  /**
     Display a deprecation warning with the provided message and a stack trace
     (Chrome and Firefox only). Ember build tools will remove any calls to
     `Ember.deprecate()` when doing a production build.
@@ -1591,7 +1586,6 @@ enifed('ember-debug/deprecate', ['exports', 'ember-metal/core', 'ember-metal/err
       `id` for this deprecation. The `id` can be used by Ember debugging tools
       to change the behavior (raise, log or silence) for that specific deprecation.
       The `id` should be namespaced by dots, e.g. "view.helper.select".
-    @for Ember
     @public
   */
 
@@ -1692,11 +1686,6 @@ enifed('ember-debug/warn', ['exports', 'ember-metal/core', 'ember-metal/logger',
 
   exports.missingOptionsIdDeprecation = missingOptionsIdDeprecation;
   /**
-  @module ember
-  @submodule ember-debug
-  */
-
-  /**
     Display a warning with the provided message. Ember build tools will
     remove any calls to `Ember.warn()` when doing a production build.
   
@@ -1704,11 +1693,6 @@ enifed('ember-debug/warn', ['exports', 'ember-metal/core', 'ember-metal/logger',
     @param {String} message A warning to display.
     @param {Boolean} test An optional boolean. If falsy, the warning
       will be displayed.
-    @param {Object} options An ojbect that can be used to pass a unique
-      `id` for this warning.  The `id` can be used by Ember debugging tools
-      to change the behavior (raise, log, or silence) for that specific warning.
-      The `id` should be namespaced by dots, e.g. "ember-debug.feature-flag-with-features-stripped"
-    @for Ember
     @public
   */
 
@@ -4390,7 +4374,7 @@ enifed('ember-metal/core', ['exports', 'ember-metal/assert'], function (exports,
   
     @class Ember
     @static
-    @version 2.1.0+45f524a3
+    @version 2.1.0
     @public
   */
 
@@ -4424,11 +4408,11 @@ enifed('ember-metal/core', ['exports', 'ember-metal/assert'], function (exports,
   
     @property VERSION
     @type String
-    @default '2.1.0+45f524a3'
+    @default '2.1.0'
     @static
     @public
   */
-  Ember.VERSION = '2.1.0+45f524a3';
+  Ember.VERSION = '2.1.0';
 
   /**
     The hash of environment variables used to control various configuration
@@ -4711,7 +4695,6 @@ enifed('ember-metal/environment', ['exports', 'ember-metal/core'], function (exp
       hasDOM: true,
       isChrome: !!window.chrome && !window.opera,
       isFirefox: typeof InstallTrigger !== 'undefined',
-      isPhantom: !!window.callPhantom,
       location: window.location,
       history: window.history,
       userAgent: window.navigator.userAgent,
@@ -4722,7 +4705,6 @@ enifed('ember-metal/environment', ['exports', 'ember-metal/core'], function (exp
       hasDOM: false,
       isChrome: false,
       isFirefox: false,
-      isPhantom: false,
       location: null,
       history: null,
       userAgent: 'Lynx (textmode)',
@@ -10942,7 +10924,7 @@ enifed('ember-metal/utils', ['exports'], function (exports) {
   var checkHasSuper = (function () {
     var sourceAvailable = (function () {
       return this;
-    }).toString().indexOf('return this') > -1;
+    }).toString().indexOf('return this;') > -1;
 
     if (sourceAvailable) {
       return function checkHasSuper(func) {
@@ -10955,7 +10937,6 @@ enifed('ember-metal/utils', ['exports'], function (exports) {
     };
   })();
 
-  exports.checkHasSuper = checkHasSuper;
   function ROOT() {}
   ROOT.__hasSuper = false;
 
@@ -12513,7 +12494,7 @@ enifed('ember-template-compiler/system/compile_options', ['exports', 'ember-meta
     options.buildMeta = function buildMeta(program) {
       return {
         topLevel: detectTopLevel(program),
-        revision: 'Ember@2.1.0+45f524a3',
+        revision: 'Ember@2.1.0',
         loc: program.loc,
         moduleName: options.moduleName
       };


### PR DESCRIPTION
The builds used originally are the ones from https://github.com/emberjs/ember.js/commit/45f524a3f23de99b141f80ace2edecd8098d3ff0, which is a few commits after the 2.1.0 tagged release.

Compare view:

https://github.com/emberjs/ember.js/compare/v2.1.0...45f524a3

None of these changes should be appreciable, but I wanted to make sure we were using the official tagged builds:

http://builds.emberjs.com/tags/v2.1.0/ember.prod.js
http://builds.emberjs.com/tags/v2.1.0/ember-template-compiler.js