### PR TITLE
load benchmarks automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,13 @@ the performance of the Ember.js framework. The general strategy is:
 - Record Baseline performance so that we can compare Ember to the
   baseline performance of the platform it's run on.
 
+### bench.json
+
+* name: humanized name
+* description: TL;DR of the benchmark, sometimes notes can be handy to display
+* keywords: these are meant to label/categorize tests, allowing tooling and users to quickly group and differentiate
+* disabled: allows for a test to be entirely disabled
+
 ### To run in development mode
 
 1. `npm install`

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -1,42 +1,7 @@
 import Ember from 'ember';
 import config from 'ember-performance/config/environment';
 
-const TEST_LIST = [ // TODO: Populate this automatically from the test definitions
-  { name: 'Baseline: Render List',     path: '/baseline-render-list'     },
-  { name: 'Baseline: Handlebars List', path: '/baseline-handlebars-list' },
-
-  { name: 'Ember.get',                 path: '/ember-get' },
-  { name: 'Ember.set',                 path: '/ember-set' },
-  { name: 'Ember.set (primed)',        path: '/ember-set/primed' },
-  { name: 'Ember.get (primed)',        path: '/ember-get/primed' },
-  { name: 'Ember.run',                 path: '/ember-run' },
-
-  // this test is broken in 1.11 beta
-  // { name: 'link-to get(\'active\')',   path: '/link-to/active' },
-
-  { name: 'link-to get(\'create\')',   path: '/link-to/create' },
-
-  { name: 'object-create/component',   path: '/object-create/component'   },
-  { name: 'object-create/baseline',    path: '/object-create/baseline'   },
-  { name: 'object-create/index',       path: '/object-create' },
-
-  // Basically, browisers (v8 included have mega slow defineProp ...)
-  // - https://code.google.com/p/v8/issues/detail?id=3649
-  // - there is a FF ticket I opened, but couldn't find it quickly :P
-  // - Jakob is working on it from the v8 side.
-  { name: 'object-create/without-non-enumerable-safety', path: '/object-create/without-non-enumerable-safety' },
-  { name: 'object-create/without-non-enumerable-safety-same-class', path: '/object-create/without-non-enumerable-safety-same-class' },
-
-  { name: 'Render List',               path: '/render-list'   },
-  { name: 'Render List (Unbound)',     path: '/render-list-unbound' },
-  { name: 'Render Complex List',       path: '/render-complex-list' },
-  { name: 'Render Complex List (HTML)',path: '/render-complex-html' },
-
-  { name: 'Render Simple Ember List',  path: '/render-simple-ember-list' },
-  { name: 'Render List with link-to',  path: '/render-list-with-link-to' },
-  { name: 'Render link-to',            path: '/render-link-to' }
-];
-
+const BENCHMARKS = config.BENCHMARKS;
 const EMBER_VERSIONS = [];
 
 config.LOCAL_EMBER_VERSIONS.forEach(version => {
@@ -75,7 +40,7 @@ export default Ember.Route.extend({
   model() {
     let session = window.TestSession.recover();
 
-    let tests = TEST_LIST.map(test => {
+    let tests = BENCHMARKS.map(test => {
       if (session) {
         test.isEnabled = session.isTestEnabled(test);
       } else {

--- a/benchmarks/baseline-handlebars-list/bench.json
+++ b/benchmarks/baseline-handlebars-list/bench.json
@@ -1,0 +1,3 @@
+{
+  "name": "Baseline: Handlebars list"
+}

--- a/benchmarks/baseline-render-list/bench.json
+++ b/benchmarks/baseline-render-list/bench.json
@@ -1,0 +1,4 @@
+{
+  "name": "Baseline: Render List",
+  "keywords": []
+}

--- a/benchmarks/baseline/bench.json
+++ b/benchmarks/baseline/bench.json
@@ -1,0 +1,4 @@
+{
+  "name": "Ember.Object.create",
+  "keywords": []
+}

--- a/benchmarks/ember-get/bench.json
+++ b/benchmarks/ember-get/bench.json
@@ -1,0 +1,4 @@
+{
+  "name": "Ember.get",
+  "keywords": []
+}

--- a/benchmarks/ember-get/primed/bench.json
+++ b/benchmarks/ember-get/primed/bench.json
@@ -1,0 +1,4 @@
+{
+  "name": "Ember.get (primed)",
+  "keywords": []
+}

--- a/benchmarks/ember-run/bench.json
+++ b/benchmarks/ember-run/bench.json
@@ -1,0 +1,4 @@
+{
+  "name": "Ember.run",
+  "keywords": []
+}

--- a/benchmarks/ember-set/bench.json
+++ b/benchmarks/ember-set/bench.json
@@ -1,0 +1,4 @@
+{
+  "name": "Ember.set",
+  "keywords": []
+}

--- a/benchmarks/ember-set/primed/bench.json
+++ b/benchmarks/ember-set/primed/bench.json
@@ -1,0 +1,4 @@
+{
+  "name": "Ember.set (primed)",
+  "keywords": []
+}

--- a/benchmarks/link-to/active/bench.json
+++ b/benchmarks/link-to/active/bench.json
@@ -1,4 +1,5 @@
 {
   "name": "link-to get('active')",
-  "keywords": []
+  "keywords": [],
+  "disabled": true
 }

--- a/benchmarks/link-to/active/bench.json
+++ b/benchmarks/link-to/active/bench.json
@@ -1,0 +1,4 @@
+{
+  "name": "link-to get('active')",
+  "keywords": []
+}

--- a/benchmarks/link-to/create/bench.json
+++ b/benchmarks/link-to/create/bench.json
@@ -1,0 +1,4 @@
+{
+  "name": "Ember.LinkView.create",
+  "keywords": []
+}

--- a/benchmarks/link-to/rendered/bench.json
+++ b/benchmarks/link-to/rendered/bench.json
@@ -1,0 +1,4 @@
+{
+  "name": "link-to get('active') – rendered",
+  "keywords": []
+}

--- a/benchmarks/object-create/baseline/bench.json
+++ b/benchmarks/object-create/baseline/bench.json
@@ -1,0 +1,4 @@
+{
+  "name": "Ember.Object.create (baseline)",
+  "keywords": []
+}

--- a/benchmarks/object-create/bench.json
+++ b/benchmarks/object-create/bench.json
@@ -1,0 +1,4 @@
+{
+  "name": "Ember.Object.create",
+  "keywords": []
+}

--- a/benchmarks/object-create/component/bench.json
+++ b/benchmarks/object-create/component/bench.json
@@ -1,0 +1,4 @@
+{
+  "name": "Ember.Component.create",
+  "keywords": []
+}

--- a/benchmarks/object-create/without-non-enumerable-safety-same-class/bench.json
+++ b/benchmarks/object-create/without-non-enumerable-safety-same-class/bench.json
@@ -1,0 +1,4 @@
+{
+  "name": "Ember.Object.create (without non-enumerable safety but same class)[Common Case]",
+  "keywords": []
+}

--- a/benchmarks/object-create/without-non-enumerable-safety/bench.json
+++ b/benchmarks/object-create/without-non-enumerable-safety/bench.json
@@ -1,0 +1,4 @@
+{
+  "name": "Ember.Object.create (without non-enumerable safety)",
+  "keywords": []
+}

--- a/benchmarks/render-bind-attr/bench.json
+++ b/benchmarks/render-bind-attr/bench.json
@@ -1,0 +1,4 @@
+{
+  "name": "Render bind-attr",
+  "keywords": []
+}

--- a/benchmarks/render-complex-html/bench,json
+++ b/benchmarks/render-complex-html/bench,json
@@ -1,0 +1,4 @@
+{
+  "name": "Render Complex List (HTML)",
+  "keywords": []
+}

--- a/benchmarks/render-complex-list/bench.json
+++ b/benchmarks/render-complex-list/bench.json
@@ -1,0 +1,4 @@
+{
+  "name": "Render Complex List",
+  "keywords": []
+}

--- a/benchmarks/render-link-to/bench.json
+++ b/benchmarks/render-link-to/bench.json
@@ -1,0 +1,4 @@
+{
+  "name": "Render link-to",
+  "keywords": []
+}

--- a/benchmarks/render-list-unbound/bench.json
+++ b/benchmarks/render-list-unbound/bench.json
@@ -1,0 +1,4 @@
+{
+  "name": "Render List (Unbound)",
+  "keywords": []
+}

--- a/benchmarks/render-list-with-link-to/bench.json
+++ b/benchmarks/render-list-with-link-to/bench.json
@@ -1,0 +1,4 @@
+{
+  "name": "Render List with link-to",
+  "keywords": []
+}

--- a/benchmarks/render-list/bench.json
+++ b/benchmarks/render-list/bench.json
@@ -1,0 +1,4 @@
+{
+  "name": "Render List",
+  "keywords": []
+}

--- a/benchmarks/render-simple-ember-list/bench.json
+++ b/benchmarks/render-simple-ember-list/bench.json
@@ -1,0 +1,4 @@
+{
+  "name": "Render Simple Ember List",
+  "keywords": []
+}

--- a/config/environment.js
+++ b/config/environment.js
@@ -17,6 +17,8 @@ function benchmarks() {
     var data = JSON.parse(fs.readFileSync('benchmarks' + '/' + bench));
     data.path = '/' + path.dirname(bench);
     return data;
+  }).filter(function(data) {
+    return data.disabled !== false
   });
 }
 

--- a/config/environment.js
+++ b/config/environment.js
@@ -8,9 +8,22 @@ function emberVersions() {
   }).filter(Boolean);
 }
 
+var walkSync = require('walk-sync');
+var path = require('path');
+var fs = require('fs');
+
+function benchmarks() {
+  return walkSync('benchmarks', ['**/bench.json']).map(function(bench) {
+    var data = JSON.parse(fs.readFileSync('benchmarks' + '/' + bench));
+    data.path = '/' + path.dirname(bench);
+    return data;
+  });
+}
+
 module.exports = function(environment) {
   var ENV = {
     LOCAL_EMBER_VERSIONS: emberVersions(),
+    BENCHMARKS: benchmarks(),
     modulePrefix: 'ember-performance',
     environment: environment,
     baseURL: '/',

--- a/package.json
+++ b/package.json
@@ -45,5 +45,8 @@
     "ember-disable-proxy-controllers": "^1.0.0",
     "ember-export-application-global": "^1.0.3",
     "ember-google-charts": "0.1.1"
+  },
+  "dependencies": {
+    "walk-sync": "^0.2.5"
   }
 }


### PR DESCRIPTION
* introduce bench.json
* bench.json must exists in benchmarks/**/
* bench.json contains name + keywords (more likely later)
* keywords are intended as labels, groups, categories, this should allow us to add more UI to group / bulk work with specific types of tests
* bench.json also enables extracting this meta data without running the tests. We likely want to remove `name` entirely from the runtime tests