### PR TITLE
Remove duplicate baseline/bench.json.

### DIFF
--- a/benchmarks/baseline/bench.json
+++ b/benchmarks/baseline/bench.json
@@ -1,4 +1,0 @@
-{
-  "name": "Ember.Object.create",
-  "keywords": []
-}


### PR DESCRIPTION
`Ember.Object.create` was already listed under `object-create/baseline/bench.json` (which works properly), but this extra one was the first in the list and didn't work.