### PR TITLE
Lock benchmark.js version down.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "dependencies": {
     "ascii-table": "~0.0.4",
-    "benchmark": "bestiejs/benchmark.js#master",
+    "benchmark": "bestiejs/benchmark.js#f3c1476cfac950b186b167843077f2cf7014f080",
     "ember": "2.1.0",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.5",
     "ember-cli-test-loader": "ember-cli-test-loader#0.2.1",


### PR DESCRIPTION
Something on master of bestiejs/benchmark.js is causing `Benchmark.Suite` to be undefined, haven't had a chance to track this down yet but this locks it down in the meantime.