### PR TITLE
downgrade benchmark.js to 1.0.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "dependencies": {
     "ascii-table": "~0.0.4",
-    "benchmark": "bestiejs/benchmark.js#f3c1476cfac950b186b167843077f2cf7014f080",
+    "benchmark": "^1.0.0",
     "ember": "2.1.0",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.5",
     "ember-cli-test-loader": "ember-cli-test-loader#0.2.1",


### PR DESCRIPTION
Benchmark v2 has removed bower support. I've created an [issue for us to upgrade to v2](https://github.com/eviltrout/ember-performance/issues/105), but this will allow the app to run for now