### PR TITLE
Add launch-chrome script.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,7 @@ the performance of the Ember.js framework. The general strategy is:
 2. `npm install -g bower`
 3. `bower install`
 4. `npm run server`
-
-And open a browser to http://localhost:4200
+5. `bin/launch-chrome http://localhost:4200`
 
 ### To build for production mode
 

--- a/bin/launch-chrome
+++ b/bin/launch-chrome
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# check for CHROME_BIN env or just default
+cmd=${CHROME_BIN:-/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome}
+
+if [ -z "$1" ]
+then
+  echo "Usage: `basename $0` [url]"
+  exit 1
+fi
+
+user_data=`mktemp -d -t profile`
+
+"$cmd" --user-data-dir="$user_data" \
+       --no-default-browser-check \
+       --ignore-certificate-errors \
+       --metrics-recording-only \
+       --no-sandbox \
+       --no-experiments \
+       --disable-component-extensions-with-background-pages \
+       --disable-background-networking \
+       --disable-extensions \
+       --disable-default-apps \
+       --noerrdialogs \
+       --no-default-browser-check \
+       --disable-translate \
+       --no-first-run \
+       "$1"
+
+rm -rf "$user_data"


### PR DESCRIPTION
Adds small shell script to launch chrome in a way that helps avoiding trolling test runs. A few tweaks are:

* Disables extensions
* Uses a custom user data directory for each session
* Disable default apps
* Disable first run setup dialogs
* Disable default browser checks

Credit for this script goes to Kris Selden (any mistakes in porting made by me).